### PR TITLE
Wrap imports

### DIFF
--- a/example/cypress/integration/home_page_spec.js
+++ b/example/cypress/integration/home_page_spec.js
@@ -172,7 +172,7 @@ describe("The Playground", () => {
     })
   })
 
-  describe.only("Using default files", () => {
+  describe("Using default files", () => {
     it("Unloading quiz brings up default main.py file", () => {
       cy.visit("/")
       cy.get("[data-cy=unload-btn]").click()

--- a/example/cypress/integration/home_page_spec.js
+++ b/example/cypress/integration/home_page_spec.js
@@ -2,88 +2,94 @@ const program = '# A simple program\nprint("hello from", "python")\n'
 const inputUrl = "http://www.foo.bar"
 const inputToken = "123abc000"
 
-describe("The Main Page", () => {
-  it("successfully loads", () => {
-    cy.visit("/")
+describe("The Playground", () => {
+  describe("The main page", () => {
+    it("successfully loads", () => {
+      cy.visit("/")
+    })
+
+    it("has a url input field", () => {
+      cy.get("[data-cy=url-input]")
+        .find("input")
+        .type(inputUrl)
+        .should("have.value", inputUrl)
+    })
+
+    it("can get url from local storage", () => {
+      cy.visit("/")
+      window.localStorage.setItem("url", inputUrl)
+      cy.get("[data-cy=url-input]")
+        .find("input")
+        .should("have.value", inputUrl)
+    })
+
+    it("has a user token input field", () => {
+      cy.get("[data-cy=token-input]")
+        .find("input")
+        .type(inputToken)
+        .should("have.value", inputToken)
+    })
+
+    it("can get token from local storage", () => {
+      cy.visit("/")
+      window.localStorage.setItem("token", inputToken)
+      cy.get("[data-cy=token-input]")
+        .find("input")
+        .should("have.value", inputToken)
+    })
+
+    it("has a load quiz button", () => {
+      cy.get("[data-cy=load-btn]").click()
+    })
+
+    it("has an unload quiz button", () => {
+      cy.get("[data-cy=unload-btn]").click()
+    })
+
+    it("has a print editor content button", () => {
+      cy.get("[data-cy=print-btn]").click()
+    })
+
+    it("has a run code button", () => {
+      cy.get("[data-cy=run-btn]").click()
+    })
+
+    it("has a run code with wrapped imports button", () => {
+      cy.get("[data-cy=run-wrapped-btn]").click()
+    })
+
+    it("has an editor input field", () => {
+      cy.visit("/")
+      cy.get(".monaco-editor")
+        .click()
+        .focused()
+        .type("{ctrl}{end}")
+        .type("{shift}{ctrl}{home}{backspace}")
+        .type(program)
+    })
+
+    it("editor contents can be displayed as an alert", () => {
+      const stub = cy.stub()
+      cy.on("window:alert", stub)
+      cy.get("[data-cy=print-btn]")
+        .click()
+        .then(() => {
+          expect(stub.getCall(0)).to.be.calledWith(program)
+        })
+    })
+
+    it("Running python code produces output", () => {
+      cy.get("[data-cy=run-btn]").click()
+      cy.contains("hello from python")
+    })
+
+    it("close button hides output", () => {
+      cy.get("[data-cy=close-btn").click()
+      cy.contains("hello from python").should("not.exist")
+    })
   })
 
-  it("has a url input field", () => {
-    cy.get("[data-cy=url-input]")
-      .find("input")
-      .type(inputUrl)
-      .should("have.value", inputUrl)
-  })
-
-  it("can get url from local storage", () => {
-    cy.visit("/")
-    window.localStorage.setItem("url", inputUrl)
-    cy.get("[data-cy=url-input]")
-      .find("input")
-      .should("have.value", inputUrl)
-  })
-
-  it("has a user token input field", () => {
-    cy.get("[data-cy=token-input]")
-      .find("input")
-      .type(inputToken)
-      .should("have.value", inputToken)
-  })
-
-  it("can get token from local storage", () => {
-    cy.visit("/")
-    window.localStorage.setItem("token", inputToken)
-    cy.get("[data-cy=token-input]")
-      .find("input")
-      .should("have.value", inputToken)
-  })
-
-  it("has a load quiz button", () => {
-    cy.get("[data-cy=load-btn]").click()
-  })
-
-  it("has an unload quiz button", () => {
-    cy.get("[data-cy=unload-btn]").click()
-  })
-
-  it("has a print editor content button", () => {
-    cy.get("[data-cy=print-btn]").click()
-  })
-
-  it("has a run code button", () => {
-    cy.get("[data-cy=run-btn]").click()
-  })
-
-  it("has an editor input field", () => {
-    cy.visit("/")
-    cy.get(".monaco-editor")
-      .click()
-      .focused()
-      .type("{ctrl}{end}")
-      .type("{shift}{ctrl}{home}{backspace}")
-      .type(program)
-  })
-
-  it("editor contents can be displayed as an alert", () => {
-    const stub = cy.stub()
-    cy.on("window:alert", stub)
-    cy.get("[data-cy=print-btn]")
-      .click()
-      .then(() => {
-        expect(stub.getCall(0)).to.be.calledWith(program)
-      })
-  })
-
-  it("running python code produces output", () => {
-    cy.get("[data-cy=run-btn]").click()
-    cy.contains("hello from python")
-  })
-
-  it("close button hides output", () => {
-    cy.get("[data-cy=close-btn").click()
-    cy.contains("hello from python").should("not.exist")
-  })
-
-  describe("running python code that includes input command", () => {
+  describe("Running python code that includes input command", () => {
     const inputProgram = 'input("Enter a word:")'
 
     it("displays input prompt", () => {
@@ -120,49 +126,90 @@ describe("The Main Page", () => {
       cy.get("[data-cy=user-input-field]").should("not.exist")
       cy.contains("Waiting for input").should("not.exist")
     })
+
+    it("stops program if stop button is clicked", () => {
+      const inputProgram = 'input("Enter a word:")'
+      cy.visit("/")
+      cy.get(".monaco-editor")
+        .click()
+        .focused()
+        .type("{ctrl}{end}")
+        .type("{shift}{ctrl}{home}{backspace}")
+        .type(inputProgram)
+      cy.get("[data-cy=run-btn]").click()
+      cy.get("[data-cy=stop-btn]").click()
+      cy.get("[data-cy=stop-btn]").should("be.disabled")
+      cy.get("[data-cy=user-input-field]").should("not.exist")
+    })
+
+    it("displays running status when program is running", () => {
+      const infiniteProgram = "while True:\n  x = 0"
+      cy.visit("/")
+      cy.get(".monaco-editor")
+        .click()
+        .focused()
+        .type("{ctrl}{end}")
+        .type("{shift}{ctrl}{home}{backspace}")
+        .type(infiniteProgram)
+      cy.get("[data-cy=run-btn]").click()
+      cy.contains("Running")
+      cy.get("[data-cy=ouput-title-stop-btn]").should("not.be.disabled")
+    })
+
+    it("clicking stop button in output title stops program", () => {
+      const inputProgram = 'input("Enter a word:")'
+      cy.visit("/")
+      cy.get(".monaco-editor")
+        .click()
+        .focused()
+        .type("{ctrl}{end}")
+        .type("{shift}{ctrl}{home}{backspace}")
+        .type(inputProgram)
+      cy.get("[data-cy=run-btn]").click()
+      cy.get("[data-cy=output-title-stop-btn").click()
+      cy.get("[data-cy=output-title-stop-btn]").should("be.disabled")
+      cy.get("[data-cy=user-input-field]").should("not.exist")
+    })
   })
 
-  it("stops program if stop button is clicked", () => {
-    const inputProgram = 'input("Enter a word:")'
-    cy.visit("/")
-    cy.get(".monaco-editor")
-      .click()
-      .focused()
-      .type("{ctrl}{end}")
-      .type("{shift}{ctrl}{home}{backspace}")
-      .type(inputProgram)
-    cy.get("[data-cy=run-btn]").click()
-    cy.get("[data-cy=stop-btn]").click()
-    cy.get("[data-cy=stop-btn]").should("be.disabled")
-    cy.get("[data-cy=user-input-field]").should("not.exist")
-  })
+  describe.only("Using default files", () => {
+    it("Unloading quiz brings up default main.py file", () => {
+      cy.visit("/")
+      cy.get("[data-cy=unload-btn]").click()
+      cy.contains("main.py")
+    })
 
-  it("displays running status when program is running", () => {
-    const infiniteProgram = "while True:\n  x = 0"
-    cy.visit("/")
-    cy.get(".monaco-editor")
-      .click()
-      .focused()
-      .type("{ctrl}{end}")
-      .type("{shift}{ctrl}{home}{backspace}")
-      .type(infiniteProgram)
-    cy.get("[data-cy=run-btn]").click()
-    cy.contains("Running")
-    cy.get("[data-cy=ouput-title-stop-btn]").should("not.be.disabled")
-  })
+    it("main.py contents are displayed", () => {
+      cy.contains("# No quiz has been loaded")
+    })
 
-  it("clicking stop button in output title stops program", () => {
-    const inputProgram = 'input("Enter a word:")'
-    cy.visit("/")
-    cy.get(".monaco-editor")
-      .click()
-      .focused()
-      .type("{ctrl}{end}")
-      .type("{shift}{ctrl}{home}{backspace}")
-      .type(inputProgram)
-    cy.get("[data-cy=run-btn]").click()
-    cy.get("[data-cy=output-title-stop-btn").click()
-    cy.get("[data-cy=output-title-stop-btn]").should("be.disabled")
-    cy.get("[data-cy=user-input-field]").should("not.exist")
+    it("test.py can be selected and displayed", () => {
+      cy.get("[data-cy=select-file]")
+        .find("select")
+        .select("test.py")
+      cy.contains("# This is the default file test.py")
+    })
+
+    it("edits to source files persist", () => {
+      const testString = "Romanes eunt domus"
+      cy.get("[data-cy=select-file]")
+        .find("select")
+        .select("main.py")
+      cy.get(".monaco-editor")
+        .first()
+        .click()
+        .focused()
+        .type("{ctrl}{end}")
+        .type("{shift}{ctrl}{home}{backspace}")
+        .type(testString)
+      cy.get("[data-cy=select-file]")
+        .find("select")
+        .select("test.py")
+      cy.contains("This is the default file test.py")
+      cy.get("[data-cy=select-file]")
+        .find("select")
+        .select("main.py")
+      cy.contains(testString)
+    })
   })
 })

--- a/package-lock.json
+++ b/package-lock.json
@@ -1168,13 +1168,6 @@
       "integrity": "sha512-+XQKNI5zpxutK05hO67huUTw/2imXCuJWjnFdU63tRES/xXSX1yVR9cv/QAdO6Rii2y2tTHbzjQ4i2apLfuK0Q==",
       "requires": {
         "@types/node": "*"
-      },
-      "dependencies": {
-        "@types/node": {
-          "version": "13.9.1",
-          "resolved": "https://registry.npmjs.org/@types/node/-/node-13.9.1.tgz",
-          "integrity": "sha512-E6M6N0blf/jiZx8Q3nb0vNaswQeEyn0XlupO+xN6DtJ6r6IT4nXrTry7zhIfYvFCl3/8Cu6WIysmUBKiqV0bqQ=="
-        }
       }
     },
     "@types/minimatch": {
@@ -1186,8 +1179,7 @@
     "@types/node": {
       "version": "12.12.30",
       "resolved": "https://registry.npmjs.org/@types/node/-/node-12.12.30.tgz",
-      "integrity": "sha512-sz9MF/zk6qVr3pAnM0BSQvYIBK44tS75QC5N+VbWSE4DjCV/pJ+UzCW/F+vVnl7TkOPcuwQureKNtSSwjBTaMg==",
-      "dev": true
+      "integrity": "sha512-sz9MF/zk6qVr3pAnM0BSQvYIBK44tS75QC5N+VbWSE4DjCV/pJ+UzCW/F+vVnl7TkOPcuwQureKNtSSwjBTaMg=="
     },
     "@types/normalize-package-data": {
       "version": "2.4.0",

--- a/src/components/PyEditor.tsx
+++ b/src/components/PyEditor.tsx
@@ -33,7 +33,7 @@ const PyEditor: React.FunctionComponent<PyEditorProps> = ({
     setIsEditorReady(true)
   }
 
-  const handleChange = (ev, value) => {
+  const handleChange = (ev: any, value: any) => {
     setEditorValue(value)
     return value
   }

--- a/src/components/PyEditor.tsx
+++ b/src/components/PyEditor.tsx
@@ -6,10 +6,11 @@ import { Button } from "@material-ui/core"
 
 type PyEditorProps = {
   handleRun: (code: string) => void
+  handleRunWrapped: (code: string) => void
   allowRun?: boolean
   handleStop: () => void
   isRunning: boolean
-  editorValue
+  editorValue: string
   setEditorValue: React.Dispatch<React.SetStateAction<string>>
 }
 
@@ -19,6 +20,7 @@ const StyledButton = styled(props => <Button variant="contained" {...props} />)`
 
 const PyEditor: React.FunctionComponent<PyEditorProps> = ({
   handleRun,
+  handleRunWrapped,
   allowRun = true,
   handleStop,
   isRunning,
@@ -55,6 +57,13 @@ const PyEditor: React.FunctionComponent<PyEditorProps> = ({
         data-cy="run-btn"
       >
         Run code
+      </StyledButton>
+      <StyledButton
+        onClick={() => handleRunWrapped(editorValue)}
+        disabled={!(isEditorReady && allowRun)}
+        data-cy="run-wrapped-btn"
+      >
+        Run with wrapped imports
       </StyledButton>
       <StyledButton
         onClick={() => handleStop()}

--- a/src/components/Quiz.tsx
+++ b/src/components/Quiz.tsx
@@ -199,6 +199,7 @@ const Quiz: React.FunctionComponent<QuizProps> = ({ initialFiles }) => {
         native
         value={selectedFile.shortName}
         onChange={handleChange}
+        data-cy="select-file"
       >
         {files.length > 0 && (
           <>
@@ -232,6 +233,7 @@ const Quiz: React.FunctionComponent<QuizProps> = ({ initialFiles }) => {
 }
 
 const defaultSrcContent = `# No quiz has been loaded.
+# This is the default file main.py
 
 from .utils import greeting, getLocality
 
@@ -254,6 +256,7 @@ def foo():
 // unittest.main()
 // `
 const defaultTestContent = `# No quiz has been loaded.
+# This is the default file test.py
 
 from .main import greetWorld
 
@@ -261,6 +264,7 @@ greetWorld()
 `
 
 const defaultUtilsContent = `# No quiz has been loaded.
+# This is the default file utils.py
 
 # Mutually recursive imports are disallowed.
 # Try uncommenting the line below!

--- a/src/components/Quiz.tsx
+++ b/src/components/Quiz.tsx
@@ -54,7 +54,7 @@ const Quiz: React.FunctionComponent<QuizProps> = ({ initialFiles }) => {
   }
 
   const wrap = (source: string, presentlyImported: Array<string>) => {
-    const importAllPattern = /^import/
+    const importAllPattern = /^import \./
     const importSomePattern = /^from \.\w+ import/
     const sourceLines = source.split("\n")
     const lines = sourceLines.map((line, num) => {

--- a/src/components/Quiz.tsx
+++ b/src/components/Quiz.tsx
@@ -215,7 +215,7 @@ const defaultTestContent = `# No quiz has been loaded.
 
 from .main import greeting
 
-greeting("world")
+print(greeting("world"))
 `
 
 Quiz.defaultProps = {

--- a/src/components/Quiz.tsx
+++ b/src/components/Quiz.tsx
@@ -207,10 +207,10 @@ const Quiz: React.FunctionComponent<QuizProps> = ({ initialFiles }) => {
 
 const defaultSrcContent = `# No quiz has been loaded.
 
-from .utils import greeting
+from .utils import greeting, getLocality
 
 def greetWorld():
-  print(greeting("world"))
+  print(greeting(getLocality()))
 
 def foo():
   print("foo!")
@@ -242,6 +242,9 @@ const defaultUtilsContent = `# No quiz has been loaded.
 
 def greeting(recipient):
   return "Hello " + recipient + "!"
+
+def getLocality():
+  return "world"
 `
 
 Quiz.defaultProps = {

--- a/src/components/Quiz.tsx
+++ b/src/components/Quiz.tsx
@@ -159,17 +159,39 @@ const Quiz: React.FunctionComponent<QuizProps> = ({ initialFiles }) => {
   )
 }
 
-const defaultContent = `# No file has been loaded.
-\nfor i in range(3):\n\tprint("hello word")`
+const defaultSrcContent = `# No quiz has been loaded.
+
+def greeting(recipient):
+  return "Hello " + recipient + "!"
+  
+for i in range(3):
+  print(greeting("world"))
+`
+
+const defaultTestContent = `# No quiz has been loaded.
+
+import unittest
+
+class TestFunctions(unittest.TestCase):
+  def test_arithmetic(self):
+    self.assertEqual(42, 40+2)
+
+unittest.main()
+`
 
 Quiz.defaultProps = {
-  editorInitialValue: "",
   initialFiles: [
     {
-      fullName: "default",
-      shortName: "default",
-      originalContent: defaultContent,
-      content: defaultContent,
+      fullName: "main.py",
+      shortName: "main.py",
+      originalContent: defaultSrcContent,
+      content: defaultSrcContent,
+    },
+    {
+      fullName: "test.py",
+      shortName: "test.py",
+      originalContent: defaultTestContent,
+      content: defaultTestContent,
     },
   ],
 }

--- a/src/components/QuizLoader.tsx
+++ b/src/components/QuizLoader.tsx
@@ -1,7 +1,6 @@
 import React, { useState, useEffect } from "react"
 import { Quiz } from "./Quiz"
 import { getZippedQuiz } from "../services/quiz"
-// import { InputLabel, Select } from "@material-ui/core"
 
 type QuizLoaderProps = {
   url: string

--- a/src/components/QuizLoader.tsx
+++ b/src/components/QuizLoader.tsx
@@ -30,7 +30,7 @@ const QuizLoader: React.FunctionComponent<QuizLoaderProps> = ({
   token,
 }) => {
   const [text, setText] = useState("Initial text")
-  const [srcFiles, setSrcFiles] = useState([defaultFile] as Array<FileEntry>)
+  const [srcFiles, setSrcFiles] = useState([defaultFile])
   const [testFiles, setTestFiles] = useState([] as Array<FileEntry>)
   const mainSourceFile = "__main__.py"
 
@@ -40,15 +40,15 @@ const QuizLoader: React.FunctionComponent<QuizLoaderProps> = ({
     stateObject: object,
     setter: (newState: any, callback?: any) => void,
     main: string | null,
-  ) => {
+  ): Promise<Array<FileEntry>> => {
     const fileSelector: RegExp = RegExp(`${directory}/\\w*\\.py$`)
     const files = orderFiles(zip.file(fileSelector), main)
-    return Promise.all(files.map(f => createEntry(zip, f)))
+    return Promise.all(files.map((f: any) => createEntry(zip, f)))
   }
 
-  const orderFiles = (files, main: string | null) => {
+  const orderFiles = (files: any, main: string | null) => {
     if (main) {
-      const mainIndex = files.findIndex(file => file.name.includes(main))
+      const mainIndex = files.findIndex((file: any) => file.name.includes(main))
       if (mainIndex > -1) {
         const mainEntry = files.splice(mainIndex, 1)[0]
         files.unshift(mainEntry)
@@ -58,7 +58,7 @@ const QuizLoader: React.FunctionComponent<QuizLoaderProps> = ({
     return files
   }
 
-  const createEntry = async (zip, f) => {
+  const createEntry = async (zip: any, f: any): Promise<FileEntry> => {
     const file = zip.file(f.name)
     const content = await f.async("string")
     const fullName: string = f.name
@@ -66,8 +66,9 @@ const QuizLoader: React.FunctionComponent<QuizLoaderProps> = ({
     let shortName: string | null = null
     if (matches) {
       shortName = matches[0]
+      return { fullName, shortName, originalContent: content, content }
     }
-    return { fullName, shortName, originalContent: content, content }
+    return { fullName: "", shortName: "", originalContent: "", content: "" }
   }
 
   useEffect(() => {

--- a/src/services/import_parsing.ts
+++ b/src/services/import_parsing.ts
@@ -4,16 +4,13 @@ type PythonImport = {
 }
 
 const parseImport = (line: string): PythonImport => {
-  console.log('this is parseImport with line "' + line + '"')
   let pkg: string
   let names: Array<string>
   const simpleImportMatches = line.match(
     /^from (\.\w+) import (\w+|(\w+, ?)\w+)$/,
   )
   if (simpleImportMatches) {
-    console.log(line + " matches")
     pkg = simpleImportMatches[1]
-    console.log("pkg is " + pkg)
     names = simpleImportMatches[2].split(",").map(s => s.trim())
     return { pkg, names }
   }

--- a/src/services/import_parsing.ts
+++ b/src/services/import_parsing.ts
@@ -1,20 +1,38 @@
-type PythonImport = {
+type PythonImportAll = {
+  pkg: string
+}
+
+type PythonImportSome = {
   pkg: string
   names: Array<string>
 }
 
-const parseImport = (line: string): PythonImport => {
+/* Parse a Python import statement of the type
+"import .foo" */
+const parseImportAll = (line: string): PythonImportAll => {
   let pkg: string
-  let names: Array<string>
-  const simpleImportMatches = line.match(
-    /^from (\.\w+) import (\w+|(\w+, ?)\w+)$/,
-  )
-  if (simpleImportMatches) {
-    pkg = simpleImportMatches[1]
-    names = simpleImportMatches[2].split(",").map(s => s.trim())
-    return { pkg, names }
+  const importMatches = line.match(/^import (\.\w+)[ \t]*$/)
+  if (importMatches) {
+    pkg = importMatches[1]
+    return { pkg }
   }
-  return { pkg: "", names: [] }
+  throw "Malformed import statement"
 }
 
-export { PythonImport, parseImport }
+/* Parse a Python import statement of the type
+"import .foo" */
+const parseImportSome = (line: string): PythonImportSome => {
+  let pkg: string
+  let names: Array<string>
+  const importMatches = line.match(
+    /^from (\.\w+) import (\w+|(\w+, ?)\w+)[ \t]*$/,
+  )
+  if (importMatches) {
+    pkg = importMatches[1]
+    names = importMatches[2].split(",").map(s => s.trim())
+    return { pkg, names }
+  }
+  throw "Malformed import statement"
+}
+
+export { PythonImportAll, PythonImportSome, parseImportAll, parseImportSome }

--- a/src/services/import_parsing.ts
+++ b/src/services/import_parsing.ts
@@ -1,0 +1,23 @@
+type PythonImport = {
+  pkg: string
+  names: Array<string>
+}
+
+const parseImport = (line: string): PythonImport => {
+  console.log('this is parseImport with line "' + line + '"')
+  let pkg: string
+  let names: Array<string>
+  const simpleImportMatches = line.match(
+    /^from (\.\w+) import (\w+|(\w+, ?)\w+)$/,
+  )
+  if (simpleImportMatches) {
+    console.log(line + " matches")
+    pkg = simpleImportMatches[1]
+    console.log("pkg is " + pkg)
+    names = simpleImportMatches[2].split(",").map(s => s.trim())
+    return { pkg, names }
+  }
+  return { pkg: "", names: [] }
+}
+
+export { PythonImport, parseImport }

--- a/src/services/quiz.ts
+++ b/src/services/quiz.ts
@@ -1,7 +1,7 @@
 import axios from "axios"
 import JSZip from "jszip"
 
-const getZippedQuiz = (url: string, token: string): Promise<any> => {
+const getZippedQuiz = (url: string, token: string): Promise<JSZip> => {
   return axios
     .request({
       responseType: "arraybuffer",


### PR DESCRIPTION
This pull request introduces wrapped Python imports. Skulpt as such offers no way (that we are aware of) to import a Python module from a JavaScript string. That is where wrapped imports come to the rescue.

When the user decides to run a Python script, the code is intercepted before it is sent to the worker. If the code contains import statements where the module name is prefixed with a dot ".", the statements are replaced with the module contents.

A statement of the form "import .mymodule" is replaced with the contents of "mymodule". A statement of the form "from .mymodule import myClass" is replaced with
-  a function wrapping the contents of "mymodule" and returning the requested names
-  and an assignment with the names as leftvals and a call to the function as the rightval.