### PR TITLE
Submit quizzes (to paste), load using slugs and names

### DIFF
--- a/example/cypress/integration/home_page_spec.js
+++ b/example/cypress/integration/home_page_spec.js
@@ -1,5 +1,7 @@
 const program = '# A simple program\nprint("hello from", "python")\n'
-const inputUrl = "http://www.foo.bar"
+const inputOrganization = "test"
+const inputCourse = "python-test"
+const inputExercise = "osa01-01_hymio"
 const inputToken = "123abc000"
 
 describe("The Playground", () => {
@@ -8,19 +10,49 @@ describe("The Playground", () => {
       cy.visit("/")
     })
 
-    it("has a url input field", () => {
-      cy.get("[data-cy=url-input]")
+    it("has a organization input field", () => {
+      cy.get("[data-cy=organization-input]")
         .find("input")
-        .type(inputUrl)
-        .should("have.value", inputUrl)
+        .type(inputOrganization)
+        .should("have.value", inputOrganization)
     })
 
-    it("can get url from local storage", () => {
+    it("can get organization from local storage", () => {
       cy.visit("/")
-      window.localStorage.setItem("url", inputUrl)
-      cy.get("[data-cy=url-input]")
+      window.localStorage.setItem("organization", inputOrganization)
+      cy.get("[data-cy=organization-input]")
         .find("input")
-        .should("have.value", inputUrl)
+        .should("have.value", inputOrganization)
+    })
+
+    it("has a course input field", () => {
+      cy.get("[data-cy=course-input]")
+        .find("input")
+        .type(inputCourse)
+        .should("have.value", inputCourse)
+    })
+
+    it("can get course from local storage", () => {
+      cy.visit("/")
+      window.localStorage.setItem("course", inputCourse)
+      cy.get("[data-cy=course-input]")
+        .find("input")
+        .should("have.value", inputCourse)
+    })
+
+    it("has an exercise input field", () => {
+      cy.get("[data-cy=exercise-input]")
+        .find("input")
+        .type(inputExercise)
+        .should("have.value", inputExercise)
+    })
+
+    it("can get exercise from local storage", () => {
+      cy.visit("/")
+      window.localStorage.setItem("exercise", inputExercise)
+      cy.get("[data-cy=exercise-input]")
+        .find("input")
+        .should("have.value", inputExercise)
     })
 
     it("has a user token input field", () => {

--- a/example/src/index.tsx
+++ b/example/src/index.tsx
@@ -21,7 +21,6 @@ const App = () => {
   const exercise = useInput("exercise", "")
   const token = useInput("token", "")
   const [fetch, setFetch] = useLocalStorage("fetch", false)
-  const url = `https://tmc.mooc.fi/api/v8/org/${organization.value}/courses/${course.value}/exercises/${exercise.value}`
   const handleLoad = () => {
     event.preventDefault()
     setFetch(true)
@@ -30,9 +29,18 @@ const App = () => {
     event.preventDefault()
     setFetch(false)
   }
-  const loadQuiz = (url, token) => {
-    console.log(`Got url=${url}, token=${token}`)
-    return <QuizLoader url={url} token={token} />
+  const loadQuiz = (organization, course, exercise, token) => {
+    console.log(
+      `Got organization=${organization}, course=${course}, exercise=${exercise}, token=${token}`,
+    )
+    return (
+      <QuizLoader
+        organization={organization}
+        course={course}
+        exercise={exercise}
+        token={token}
+      />
+    )
   }
 
   return (
@@ -57,7 +65,8 @@ const App = () => {
           Unload Quiz
         </StyledButton>
       </div>
-      {fetch && loadQuiz(url, token.value)}
+      {fetch &&
+        loadQuiz(organization.value, course.value, exercise.value, token.value)}
       {!fetch && <Quiz />}
     </>
   )

--- a/example/src/index.tsx
+++ b/example/src/index.tsx
@@ -16,9 +16,12 @@ const StyledButton = styled(props => <Button variant="contained" {...props} />)`
 `
 
 const App = () => {
-  const url = useInput("url", "")
+  const organization = useInput("organization", "")
+  const course = useInput("course", "")
+  const exercise = useInput("exercise", "")
   const token = useInput("token", "")
   const [fetch, setFetch] = useLocalStorage("fetch", false)
+  const url = `https://tmc.mooc.fi/api/v8/org/${organization.value}/courses/${course.value}/exercises/${exercise.value}`
   const handleLoad = () => {
     event.preventDefault()
     setFetch(true)
@@ -35,7 +38,17 @@ const App = () => {
   return (
     <>
       <div>
-        <StyledTextField {...url} label="Quiz url" data-cy="url-input" />
+        <StyledTextField
+          {...organization}
+          label="Organization slug"
+          data-cy="organization-input"
+        />
+        <StyledTextField {...course} label="Course" data-cy="course-input" />
+        <StyledTextField
+          {...exercise}
+          label="Exercise"
+          data-cy="exercise-input"
+        />
         <StyledTextField {...token} label="User token" data-cy="token-input" />
         <StyledButton onClick={handleLoad} data-cy="load-btn">
           Load Quiz
@@ -44,7 +57,7 @@ const App = () => {
           Unload Quiz
         </StyledButton>
       </div>
-      {fetch && loadQuiz(url.value, token.value)}
+      {fetch && loadQuiz(url, token.value)}
       {!fetch && <Quiz />}
     </>
   )

--- a/package-lock.json
+++ b/package-lock.json
@@ -3456,16 +3456,6 @@
       "resolved": "https://registry.npmjs.org/forever-agent/-/forever-agent-0.6.1.tgz",
       "integrity": "sha1-+8cfDEGt6zf5bFd60e1C2P2sypE="
     },
-    "form-data": {
-      "version": "2.3.3",
-      "resolved": "https://registry.npmjs.org/form-data/-/form-data-2.3.3.tgz",
-      "integrity": "sha512-1lLKB2Mu3aGP1Q/2eCOx0fNbRMe7XdwktwOruhfqqd0rIJWwN4Dh+E3hrPSlDCXnSR7UtZ1N38rVXm+6+MEhJQ==",
-      "requires": {
-        "asynckit": "^0.4.0",
-        "combined-stream": "^1.0.6",
-        "mime-types": "^2.1.12"
-      }
-    },
     "fragment-cache": {
       "version": "0.2.1",
       "resolved": "https://registry.npmjs.org/fragment-cache/-/fragment-cache-0.2.1.tgz",
@@ -7277,6 +7267,18 @@
         "tough-cookie": "~2.5.0",
         "tunnel-agent": "^0.6.0",
         "uuid": "^3.3.2"
+      },
+      "dependencies": {
+        "form-data": {
+          "version": "2.3.3",
+          "resolved": "https://registry.npmjs.org/form-data/-/form-data-2.3.3.tgz",
+          "integrity": "sha512-1lLKB2Mu3aGP1Q/2eCOx0fNbRMe7XdwktwOruhfqqd0rIJWwN4Dh+E3hrPSlDCXnSR7UtZ1N38rVXm+6+MEhJQ==",
+          "requires": {
+            "asynckit": "^0.4.0",
+            "combined-stream": "^1.0.6",
+            "mime-types": "^2.1.12"
+          }
+        }
       }
     },
     "request-promise-core": {

--- a/src/components/Output.tsx
+++ b/src/components/Output.tsx
@@ -17,6 +17,9 @@ type OutputProps = {
   inputRequested: boolean
   sendInput: (input: string) => void
   isRunning: boolean
+  handleSubmit: () => void
+  handlePasteSubmit: () => void
+  isSubmitting: boolean
   handleStop: () => void
 }
 
@@ -106,6 +109,9 @@ const Output: React.FunctionComponent<OutputProps> = props => {
     inputRequested,
     sendInput,
     isRunning,
+    handleSubmit,
+    handlePasteSubmit,
+    isSubmitting,
     handleStop,
   } = props
 
@@ -198,6 +204,22 @@ const Output: React.FunctionComponent<OutputProps> = props => {
                 data-cy="output-title-stop-btn"
               >
                 Stop
+              </MarginedButton>
+              <MarginedButton
+                onClick={handleSubmit}
+                variant="contained"
+                disabled={isSubmitting}
+                data-cy="submit-btn"
+              >
+                Submit solution
+              </MarginedButton>
+              <MarginedButton
+                onClick={handlePasteSubmit}
+                variant="contained"
+                disabled={isSubmitting}
+                data-cy="paste-btn"
+              >
+                Send to TMC Paste
               </MarginedButton>
               <MarginedButton
                 onClick={closeOutput}

--- a/src/components/Output.tsx
+++ b/src/components/Output.tsx
@@ -169,17 +169,23 @@ const Output: React.FunctionComponent<OutputProps> = props => {
     ),
   )
 
-  const statusText = !isRunning
-    ? null
-    : inputRequested
-    ? "Waiting for input"
-    : "Running"
+  const getStatusText = () => {
+    if (isRunning) {
+      return inputRequested ? "Waiting for input" : "Running"
+    } else if (isSubmitting) {
+      return "Submitting"
+    }
+    return null
+  }
 
-  const statusIcon = !isRunning ? null : inputRequested ? (
-    <FontAwesomeIcon icon={faExclamation} />
-  ) : (
-    <CircularProgress size={25} color="inherit" disableShrink />
-  )
+  const getStatusIcon = () => {
+    if (isRunning && inputRequested) {
+      return <FontAwesomeIcon icon={faExclamation} />
+    } else if (isRunning || isSubmitting) {
+      return <CircularProgress size={25} color="inherit" disableShrink />
+    }
+    return null
+  }
 
   return (
     <ContainerBox data-cy="output-container">
@@ -194,8 +200,8 @@ const Output: React.FunctionComponent<OutputProps> = props => {
           >
             <OutputTitle>Output</OutputTitle>
             <Grid container item xs={8} alignItems="center" justify="flex-end">
-              {statusIcon}
-              <StatusText>{statusText}</StatusText>
+              {getStatusIcon()}
+              <StatusText>{getStatusText()}</StatusText>
               <MarginedButton
                 onClick={handleStop}
                 variant="contained"
@@ -208,7 +214,7 @@ const Output: React.FunctionComponent<OutputProps> = props => {
               <MarginedButton
                 onClick={handleSubmit}
                 variant="contained"
-                disabled={isSubmitting}
+                disabled={isSubmitting || isRunning}
                 data-cy="submit-btn"
               >
                 Submit solution
@@ -216,7 +222,7 @@ const Output: React.FunctionComponent<OutputProps> = props => {
               <MarginedButton
                 onClick={handlePasteSubmit}
                 variant="contained"
-                disabled={isSubmitting}
+                disabled={isSubmitting || isRunning}
                 data-cy="paste-btn"
               >
                 Send to TMC Paste
@@ -224,6 +230,7 @@ const Output: React.FunctionComponent<OutputProps> = props => {
               <MarginedButton
                 onClick={closeOutput}
                 variant="contained"
+                disabled={isSubmitting}
                 data-cy="close-btn"
               >
                 Close

--- a/src/components/PyEditor.tsx
+++ b/src/components/PyEditor.tsx
@@ -9,9 +9,6 @@ type PyEditorProps = {
   allowRun?: boolean
   handleStop: () => void
   isRunning: boolean
-  handleSubmit: () => void
-  handlePasteSubmit: () => void
-  isSubmitting: boolean
   editorValue: string
   setEditorValue: React.Dispatch<React.SetStateAction<string>>
 }
@@ -25,10 +22,7 @@ const PyEditor: React.FunctionComponent<PyEditorProps> = ({
   handleRunWrapped,
   allowRun = true,
   handleStop,
-  handleSubmit,
-  handlePasteSubmit,
   isRunning,
-  isSubmitting,
   editorValue,
   setEditorValue,
 }) => {
@@ -79,20 +73,6 @@ const PyEditor: React.FunctionComponent<PyEditorProps> = ({
         data-cy="stop-btn"
       >
         Stop
-      </StyledButton>
-      <StyledButton
-        onClick={handleSubmit}
-        disabled={isSubmitting}
-        data-cy="submit-btn"
-      >
-        Submit exercise
-      </StyledButton>
-      <StyledButton
-        onClick={handlePasteSubmit}
-        disabled={isSubmitting}
-        data-cy="tmc-paste-btn"
-      >
-        Send to TMC paste
       </StyledButton>
       <ControlledEditor
         value={editorValue}

--- a/src/components/PyEditor.tsx
+++ b/src/components/PyEditor.tsx
@@ -8,7 +8,9 @@ type PyEditorProps = {
   handleRunWrapped: (code: string) => void
   allowRun?: boolean
   handleStop: () => void
+  handleSubmit: () => void
   isRunning: boolean
+  isSubmitting: boolean
   editorValue: string
   setEditorValue: React.Dispatch<React.SetStateAction<string>>
 }
@@ -22,7 +24,9 @@ const PyEditor: React.FunctionComponent<PyEditorProps> = ({
   handleRunWrapped,
   allowRun = true,
   handleStop,
+  handleSubmit,
   isRunning,
+  isSubmitting,
   editorValue,
   setEditorValue,
 }) => {
@@ -73,6 +77,13 @@ const PyEditor: React.FunctionComponent<PyEditorProps> = ({
         data-cy="stop-btn"
       >
         Stop
+      </StyledButton>
+      <StyledButton
+        onClick={handleSubmit}
+        disabled={isSubmitting}
+        data-cy="submit-btn"
+      >
+        Submit exercise
       </StyledButton>
       <ControlledEditor
         value={editorValue}

--- a/src/components/PyEditor.tsx
+++ b/src/components/PyEditor.tsx
@@ -8,8 +8,9 @@ type PyEditorProps = {
   handleRunWrapped: (code: string) => void
   allowRun?: boolean
   handleStop: () => void
-  handleSubmit: () => void
   isRunning: boolean
+  handleSubmit: () => void
+  handlePasteSubmit: () => void
   isSubmitting: boolean
   editorValue: string
   setEditorValue: React.Dispatch<React.SetStateAction<string>>
@@ -25,6 +26,7 @@ const PyEditor: React.FunctionComponent<PyEditorProps> = ({
   allowRun = true,
   handleStop,
   handleSubmit,
+  handlePasteSubmit,
   isRunning,
   isSubmitting,
   editorValue,
@@ -84,6 +86,13 @@ const PyEditor: React.FunctionComponent<PyEditorProps> = ({
         data-cy="submit-btn"
       >
         Submit exercise
+      </StyledButton>
+      <StyledButton
+        onClick={handlePasteSubmit}
+        disabled={isSubmitting}
+        data-cy="tmc-paste-btn"
+      >
+        Send to TMC paste
       </StyledButton>
       <ControlledEditor
         value={editorValue}

--- a/src/components/Quiz.tsx
+++ b/src/components/Quiz.tsx
@@ -12,6 +12,7 @@ import {
 } from "../services/import_parsing"
 
 type QuizProps = {
+  submitQuiz: (files: Array<FileEntry>) => Promise<string>
   initialFiles: Array<FileEntry>
 }
 
@@ -24,7 +25,10 @@ const defaultFile: FileEntry = {
   content: "",
 }
 
-const Quiz: React.FunctionComponent<QuizProps> = ({ initialFiles }) => {
+const Quiz: React.FunctionComponent<QuizProps> = ({
+  submitQuiz,
+  initialFiles,
+}) => {
   const [output, setOutput] = useState<any>([])
   const [workerAvailable, setWorkerAvailable] = useState(true)
   const [inputRequested, setInputRequested] = useState(false)
@@ -32,6 +36,7 @@ const Quiz: React.FunctionComponent<QuizProps> = ({ initialFiles }) => {
   const [selectedFile, setSelectedFile] = useState(defaultFile)
   const [editorValue, setEditorValue] = useState("")
   const [running, setRunning] = useState(false)
+  const [submiting, setSubmitting] = useState(false)
 
   function handleRun(code: string) {
     if (workerAvailable) {
@@ -151,6 +156,16 @@ const Quiz: React.FunctionComponent<QuizProps> = ({ initialFiles }) => {
   }
 
   const handleChange = (e: any) => {
+    setStateForSelectedFile()
+    changeFile(e.target.value, files)
+  }
+
+  const handleSubmit = () => {
+    setStateForSelectedFile()
+    setSubmitting(true)
+  }
+
+  const setStateForSelectedFile = () => {
     setFiles((prev: any) =>
       prev.map((file: any) =>
         file.shortName === selectedFile.shortName
@@ -158,7 +173,6 @@ const Quiz: React.FunctionComponent<QuizProps> = ({ initialFiles }) => {
           : file,
       ),
     )
-    changeFile(e.target.value, files)
   }
 
   const changeFile = (shortName: string, fileList: Array<object>) => {
@@ -179,6 +193,15 @@ const Quiz: React.FunctionComponent<QuizProps> = ({ initialFiles }) => {
     setFiles(initialFiles)
     changeFile(initialFiles[0].shortName, initialFiles)
   }, [initialFiles])
+
+  useEffect(() => {
+    if (submiting) {
+      submitQuiz(files).then(data => {
+        alert(data)
+        setSubmitting(false)
+      })
+    }
+  }, [submiting])
 
   const stopWorker = () => {
     if (!workerAvailable) {
@@ -221,7 +244,9 @@ const Quiz: React.FunctionComponent<QuizProps> = ({ initialFiles }) => {
         handleRunWrapped={handleRunWrapped}
         allowRun={workerAvailable}
         handleStop={stopWorker}
+        handleSubmit={handleSubmit}
         isRunning={running}
+        isSubmitting={submiting}
         editorValue={editorValue}
         setEditorValue={setEditorValue}
       />
@@ -272,6 +297,7 @@ def getLocality():
 `
 
 Quiz.defaultProps = {
+  submitQuiz: () => Promise.resolve("default submission called"),
   initialFiles: [
     {
       fullName: "main.py",

--- a/src/components/Quiz.tsx
+++ b/src/components/Quiz.tsx
@@ -251,9 +251,6 @@ const Quiz: React.FunctionComponent<QuizProps> = ({
         allowRun={workerAvailable}
         handleStop={stopWorker}
         isRunning={running}
-        handleSubmit={() => handleSubmit(false)}
-        handlePasteSubmit={() => handleSubmit(true)}
-        isSubmitting={submitStatus.submiting}
         editorValue={editorValue}
         setEditorValue={setEditorValue}
       />
@@ -263,6 +260,9 @@ const Quiz: React.FunctionComponent<QuizProps> = ({
         inputRequested={inputRequested}
         sendInput={sendInput}
         isRunning={running}
+        handleSubmit={() => handleSubmit(false)}
+        handlePasteSubmit={() => handleSubmit(true)}
+        isSubmitting={submitStatus.submiting}
         handleStop={stopWorker}
       />
     </div>

--- a/src/components/QuizLoader.tsx
+++ b/src/components/QuizLoader.tsx
@@ -1,6 +1,10 @@
 import React, { useState, useEffect } from "react"
 import { Quiz, defaultFile } from "./Quiz"
-import { getZippedQuiz, submitQuiz } from "../services/quiz"
+import {
+  getZippedQuiz,
+  submitQuiz,
+  fetchSubmissionResult,
+} from "../services/quiz"
 
 type QuizLoaderProps = {
   organization: string
@@ -69,6 +73,12 @@ const QuizLoader: React.FunctionComponent<QuizLoaderProps> = ({
     return { fullName: "", shortName: "", originalContent: "", content: "" }
   }
 
+  const submitAndWaitResult = async (files: Array<FileEntry>) => {
+    const resultUrl = await submitQuiz(submissionUrl, token, files)
+    const testCases = await fetchSubmissionResult(resultUrl, token)
+    return testCases[0].name
+  }
+
   useEffect(() => {
     const url = `https://tmc.mooc.fi/api/v8/org/${organization}/courses/${course}/exercises/${exercise}`
     Promise.all(getZippedQuiz(url, token))
@@ -86,7 +96,7 @@ const QuizLoader: React.FunctionComponent<QuizLoaderProps> = ({
     <>
       <Quiz
         initialFiles={srcFiles}
-        submitQuiz={files => submitQuiz(submissionUrl, token, files)}
+        submitQuiz={submitAndWaitResult}
         submitToPaste={files =>
           submitQuiz(submissionUrl, token, files, { paste: true })
         }

--- a/src/components/QuizLoader.tsx
+++ b/src/components/QuizLoader.tsx
@@ -1,6 +1,6 @@
 import React, { useState, useEffect } from "react"
 import { Quiz, defaultFile } from "./Quiz"
-import { getZippedQuiz } from "../services/quiz"
+import { getZippedQuiz, submitQuiz } from "../services/quiz"
 
 type QuizLoaderProps = {
   url: string
@@ -76,7 +76,10 @@ const QuizLoader: React.FunctionComponent<QuizLoaderProps> = ({
 
   return (
     <>
-      <Quiz initialFiles={srcFiles} />
+      <Quiz
+        initialFiles={srcFiles}
+        submitQuiz={files => submitQuiz(url, token, files)}
+      />
     </>
   )
 }

--- a/src/components/QuizLoader.tsx
+++ b/src/components/QuizLoader.tsx
@@ -3,7 +3,9 @@ import { Quiz, defaultFile } from "./Quiz"
 import { getZippedQuiz, submitQuiz } from "../services/quiz"
 
 type QuizLoaderProps = {
-  url: string
+  organization: string
+  course: string
+  exercise: string
   token: string
 }
 
@@ -19,7 +21,9 @@ type FileEntry = {
     file whose path contains "/src/__main__.py".
 */
 const QuizLoader: React.FunctionComponent<QuizLoaderProps> = ({
-  url,
+  organization,
+  course,
+  exercise,
   token,
 }) => {
   const [text, setText] = useState("Initial text")
@@ -66,6 +70,7 @@ const QuizLoader: React.FunctionComponent<QuizLoaderProps> = ({
   }
 
   useEffect(() => {
+    const url = `https://tmc.mooc.fi/api/v8/org/${organization}/courses/${course}/exercises/${exercise}`
     Promise.all(getZippedQuiz(url, token))
       .then(result => {
         const [zip, subm] = result

--- a/src/components/QuizLoader.tsx
+++ b/src/components/QuizLoader.tsx
@@ -25,6 +25,7 @@ const QuizLoader: React.FunctionComponent<QuizLoaderProps> = ({
   const [text, setText] = useState("Initial text")
   const [srcFiles, setSrcFiles] = useState([defaultFile])
   const [testFiles, setTestFiles] = useState([] as Array<FileEntry>)
+  const [submissionUrl, setSubmissionUrl] = useState("")
   const mainSourceFile = "__main__.py"
 
   const getFileEntries = (
@@ -65,10 +66,12 @@ const QuizLoader: React.FunctionComponent<QuizLoaderProps> = ({
   }
 
   useEffect(() => {
-    getZippedQuiz(url, token)
-      .then(zip =>
-        getFileEntries(zip, "src", srcFiles, setSrcFiles, mainSourceFile),
-      )
+    Promise.all(getZippedQuiz(url, token))
+      .then(result => {
+        const [zip, subm] = result
+        setSubmissionUrl(() => subm)
+        return getFileEntries(zip, "src", srcFiles, setSrcFiles, mainSourceFile)
+      })
       .then(fileEntries => {
         setSrcFiles(() => fileEntries)
       })
@@ -78,7 +81,7 @@ const QuizLoader: React.FunctionComponent<QuizLoaderProps> = ({
     <>
       <Quiz
         initialFiles={srcFiles}
-        submitQuiz={files => submitQuiz(url, token, files)}
+        submitQuiz={files => submitQuiz(submissionUrl, token, files)}
       />
     </>
   )

--- a/src/components/QuizLoader.tsx
+++ b/src/components/QuizLoader.tsx
@@ -82,6 +82,9 @@ const QuizLoader: React.FunctionComponent<QuizLoaderProps> = ({
       <Quiz
         initialFiles={srcFiles}
         submitQuiz={files => submitQuiz(submissionUrl, token, files)}
+        submitToPaste={files =>
+          submitQuiz(submissionUrl, token, files, { paste: true })
+        }
       />
     </>
   )


### PR DESCRIPTION
This pull request allows sending loaded quizzes back to TMC server.  It also changes the way quizzes are loaded as they now use slugs from organization, course & exercise.

At the moment these actions only give a link to the created submission. When possible, test results can be fetched and shown to the user.

At the moment the ID of an exercise must be resolved to be able to submit it. Whether there is a similar API endpoint for exercise POST requests needs to be verified.