### PR TITLE
Fix error display

### DIFF
--- a/src/components/worker.js
+++ b/src/components/worker.js
@@ -132,7 +132,7 @@ function run(code) {
     })
     .catch(e => {
       console.log(e)
-      postMessage({ type: "error", msg: e.toString() })
+      printBuffer.push({ type: "error", msg: e.toString() })
     })
     .finally(() => {
       running = false


### PR DESCRIPTION
Adds a bug fix for the error display, where a runtime error was printed in an arbitrary place among the other output lines. To assure the error is showed in the right place, the web worker now adds the error message in the buffer for printable output instead of posting it to the main thread right away, which was causing the problem.