### PR TITLE
print() in mooc.fi editor doesn't behave like python's print() - how to fix this

### DIFF
--- a/src/components/worker.js
+++ b/src/components/worker.js
@@ -58,7 +58,10 @@ let prevDate = null
  */
 self.print = function (...args) {
   let kwargs = {}
-  if (typeof args[args.length - 1] === "object") {
+  // easiest fix to deal with empty print output on trailing lists/dicts: 
+  // check that the last argument isn't a pyproxy object 
+  last = args[args.length-1]
+  if (!pyodide.isPyProxy(last) && typeof last === "object") {
     kwargs = args.pop()
   }
   const text = args.join(kwargs?.sep ?? " ") + (kwargs?.end ?? "\n")

--- a/src/components/worker.js
+++ b/src/components/worker.js
@@ -53,18 +53,12 @@ const printBufferManager = (runInIntervals) => {
 
 let prevDate = null
 /**
- * Python print alias when running with Pyodide. include lines
- * `from js import print` and `__builtins__.print = print` to use.
+ * NEW python print alias when running with Pyodide.
+ * Renamed to free `print` as function name.
+ * No longer has javascript touching the formatting, instead python handles it in run() function below
  */
-self.print = function (...args) {
-  let kwargs = {}
-  // easiest fix to deal with empty print output on trailing lists/dicts: 
-  // check that the last argument isn't a pyproxy object 
-  last = args[args.length-1]
-  if (!pyodide.isPyProxy(last) && typeof last === "object") {
-    kwargs = args.pop()
-  }
-  const text = args.join(kwargs?.sep ?? " ") + (kwargs?.end ?? "\n")
+self.printText = function (text) {
+  // turned into a dumb buffer
   printBuffer.push(text)
 
   // If code is in loop, intervalManager doesn't print batches(?)
@@ -123,7 +117,13 @@ ${code
     pass # SyntaxError: EOF - Missing end parentheses at end of code?
 
 import asyncio, sys, traceback
-from js import exit, inputPromise, print, printError, wait
+from js import exit, inputPromise, printText, printError, wait
+
+# let python handle the formatting
+# why chr(10) instead of "/n"? it's complicated (SyntaxErrors galore, due to two string layers)
+def print(*args, sep=None, end=None, file=None, flush=False):
+    printText((" " if sep is None else sep).join(str(a) for a in args)
+              + (chr(10) if end is None else end))
 
 async def input(prompt=None):
     if prompt:

--- a/standalone-editor.html
+++ b/standalone-editor.html
@@ -1,0 +1,34 @@
+<!doctype html><meta charset="utf-8">
+<!-- to test this, cd to root, run `python3 -m http.server 8000`, open http://localhost:8000/standalone-editor.html -->
+<textarea id="code" rows="12" cols="60">print([1, 2, 3])
+print({"something": 1.0})
+print(None)
+print(False)
+print(1.0)
+print("a\nb")
+# the next two should end up like: x!A-B
+print("x", end="!")
+print("A", "B", sep="-")
+print("all working as expected!")
+
+print("\nwell...")
+print("""a\n    b""") # indentation vanishes! (but whatever)</textarea>
+<button id="run">RUN</button>
+<pre id="out"></pre>
+<script>
+const out = document.getElementById("out")
+document.getElementById("run").onclick = async () => {
+  out.textContent = "loading pyodide...\n"
+  const ts = await (await fetch("src/constants/workerJsSource.ts")).text()
+  const source = atob(ts.match(/atob\("([^"]+)"\)/)[1])   // exactly what useWorker.tsx does
+  const w = new Worker(URL.createObjectURL(new Blob([source], {type: "application/javascript"})))
+  w.onmessage = (e) => {
+    const {type, msg} = e.data
+    if (type === "start_run") out.textContent = ""
+    else if (type === "print_batch") out.textContent += msg.join("")
+    else if (type === "error") out.textContent += "\n[error] " + msg
+    else if (type === "print_done") { out.textContent += "\n--- done ---"; w.terminate() }
+  }
+  w.postMessage({type: "run", msg: {code: document.getElementById("code").value, debug: true}})
+}
+</script>


### PR DESCRIPTION
A friend taking the https://programming-26.mooc.fi class asked for my help, figuring out why `print([1, 2, 3])`  wasn't printing anything in the provided editor. I eventually found the source of the problem (and more) and have created the two attached commits to solve it. 

**The problem:** The editor doesn't use python's `print`. Instead, it injects a javascript function into the python namespace and lets that do the formatting. It tries to detect keyword arguments by checking whether the last argument is a JS object — but a python list arrives as a PyProxy, which is also `typeof "object"`. So `print([1, 2, 3])` mistakes the list for `end=`/`sep=` kwargs, pops it, and prints an empty line. Same for dicts, tuples, and objects.  
Related issues from the same "format Python values in JS" approach: `print(True)` -> `true`, `print(1.0)` -> `1`, `print(None)` -> blank line.  
Not exactly helpful when you're a beginner trying to troubleshoot your work and the "official" thing's output doesn't behave as expected. 

I have provided 2 fixes in separate commits:  
[Simple guard](https://github.com/rage/python-editor/commit/4f8ba13766bf931f8a130f2a4a4e00babf460bfc): just check if last argument is a PyProxy object. If so, don't throw it away! Does not change the related issues. (not recommended)

[Let python handle it](https://github.com/rage/python-editor/commit/5acb32b8322288fbe7739b390ec979ddae4e593e): instead of having javascript mess with the formatting, let python handle it, then hand a properly formatted line back to js to display. Handles all of the outlined issues. Also included: a little html page to test the changes (feel free to remove it, I added it to provide proof that it actually works -- remember to `npm run encode: worker`). (recommended)

(why does the 2nd solution use `chr(10)` for its newline? it's the only way I found to actually get it past the two-string-syntax-translation-barrier)